### PR TITLE
Added option for sortable datetimes in file names.

### DIFF
--- a/XIVLogger/ChatLog.cs
+++ b/XIVLogger/ChatLog.cs
@@ -21,6 +21,9 @@ public class ChatMessage
 
 public class ChatStorage
 {
+    private const string LEGACY_DATETIME_FORMAT = "dd-MM-yyyy_hh.mm.ss";
+    private const string SORTABLE_DATETIME_FORMAT = "yyyy-MM-dd_hh.mm.ss";
+
     private List<ChatMessage> LogList;
     private Configuration Config;
 
@@ -44,9 +47,22 @@ public class ChatStorage
         LogList.Add(new ChatMessage(type, sender, message));
     }
 
-    private static string GetTimeStamp()
+    private string GetTimeStamp()
     {
-        return DateTime.Now.ToString("dd-MM-yyyy_hh.mm.ss");
+        DateTime now = DateTime.Now;
+
+        string ret;
+
+        if (this.Config.fileSortableDatetime)
+        {
+            ret = now.ToString(SORTABLE_DATETIME_FORMAT, System.Globalization.CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            ret = now.ToString(LEGACY_DATETIME_FORMAT, System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        return ret;
     }
 
     private static bool CheckValidPath(string path)

--- a/XIVLogger/ChatLog.cs
+++ b/XIVLogger/ChatLog.cs
@@ -5,10 +5,10 @@ namespace XIVLogger;
 
 public class ChatMessage
 {
-    public XivChatType Type;
-    public string Message;
-    public string Sender;
-    public DateTime Timestamp;
+    public XivChatType Type { get; }
+    public string Message { get; }
+    public string Sender { get; }
+    public DateTime Timestamp { get; }
 
     public ChatMessage(XivChatType type, string sender, string message)
     {

--- a/XIVLogger/ChatLog.cs
+++ b/XIVLogger/ChatLog.cs
@@ -24,14 +24,20 @@ public class ChatStorage
     private const string LEGACY_DATETIME_FORMAT = "dd-MM-yyyy_hh.mm.ss";
     private const string SORTABLE_DATETIME_FORMAT = "yyyy-MM-dd_hh.mm.ss";
 
+    // We never modify this reference once it is set in the constructor.
+    private readonly Configuration Config;
+
+    // This can be readonly, but it would require using Clear() to empty it.
+    // See WipeLog() for why this is not ideal.
     private List<ChatMessage> LogList;
-    private Configuration Config;
 
     private int AutoMsgCounter;
-    private string AutoFileName = string.Empty;
+    private string AutoFileName;
 
     public ChatStorage(Configuration config)
     {
+        AutoMsgCounter = 0;
+        AutoFileName = string.Empty;
         Config = config;
         LogList = new List<ChatMessage>();
     }
@@ -39,6 +45,10 @@ public class ChatStorage
     public void WipeLog()
     {
         AutoMsgCounter = 0;
+
+        // We could invoke Clear here, but, this ensures the memory is released.
+        // List is backed by an array, similar to Java's ArrayList and clearing the
+        // array does not reduce its size.
         LogList = new List<ChatMessage>();
     }
 

--- a/XIVLogger/Configuration.cs
+++ b/XIVLogger/Configuration.cs
@@ -25,6 +25,9 @@ namespace XIVLogger
         public int fAutoMin = 5;
         public string autoFilePath = string.Empty;
 
+        // This is for file names
+        public bool fileSortableDatetime = false;
+
         [NonSerialized]
         public DalamudPluginInterface PluginInterface;
 

--- a/XIVLogger/Windows/Config.cs
+++ b/XIVLogger/Windows/Config.cs
@@ -145,6 +145,12 @@ public class ConfigWindow : Window, IDisposable
         ImGui.SameLine();
         ImGui.InputText("##autofilepath", ref Plugin.Configuration.autoFilePath, 256);
 
+        ImGuiHelpers.ScaledDummy(5.0f);
+        ImGui.Separator();
+        ImGuiHelpers.ScaledDummy(5.0f);
+
+        save |= ImGui.Checkbox("Use sortable datetime in file names", ref Plugin.Configuration.fileSortableDatetime);
+
         if (save)
             Plugin.Configuration.Save();
 

--- a/XIVLogger/XIVLogger.csproj
+++ b/XIVLogger/XIVLogger.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Authors>Infi</Authors>
-		<Version>1.0.5.3</Version>
+		<Version>1.0.5.4</Version>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
The current file names automatically generated are not sortable by name. This adds an option to change the date component order to be sortable, similar to the "s" format, but with characters that are filename friendly that mimic the style of the legacy filename.