### PR TITLE
Changed hour to be 24 hour format in sortable file name datetime pattern

### DIFF
--- a/XIVLogger/ChatLog.cs
+++ b/XIVLogger/ChatLog.cs
@@ -22,7 +22,7 @@ public class ChatMessage
 public class ChatStorage
 {
     private const string LegacyDatetimeFormat = "dd-MM-yyyy_hh.mm.ss";
-    private const string SortableDatetimeFormat = "yyyy-MM-dd_hh.mm.ss";
+    private const string SortableDatetimeFormat = "yyyy-MM-dd_HH.mm.ss";
 
     // We never modify this reference once it is set in the constructor.
     private readonly Configuration Config;


### PR DESCRIPTION
The legacy pattern is using a 12 hour clock, which does not work for a sortable datetime representation. I have changed the sortable version to use 24 hour clock. This was an oversight on my original PR.